### PR TITLE
fix: `meta_sep` token and add to registry

### DIFF
--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -68,7 +68,7 @@ impl FormattingToken {
             FormattingToken::Channel => "<|channel|>",
             FormattingToken::BeginUntrusted => "<|untrusted|>",
             FormattingToken::EndUntrusted => "<|end_untrusted|>",
-            FormattingToken::MetaSep => "<|channel|>",
+            FormattingToken::MetaSep => "<|meta_sep|>",
             FormattingToken::MetaEnd => "<|meta_end|>",
         }
     }

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -66,6 +66,8 @@ pub fn load_harmony_encoding(name: HarmonyEncodingName) -> anyhow::Result<Harmon
                     (FormattingToken::EndMessageAssistantToTool, "<|call|>"),
                     (FormattingToken::BeginUntrusted, "<|untrusted|>"),
                     (FormattingToken::EndUntrusted, "<|end_untrusted|>"),
+                    (FormattingToken::MetaSep, "<|meta_sep|>"),
+                    (FormattingToken::MetaEnd, "<|meta_end|>"),
                 ]),
                 stop_formatting_tokens: HashSet::from([
                     FormattingToken::EndMessageDoneSampling,
@@ -107,6 +109,8 @@ pub async fn load_harmony_encoding(name: HarmonyEncodingName) -> anyhow::Result<
                     (FormattingToken::EndMessageAssistantToTool, "<|call|>"),
                     (FormattingToken::BeginUntrusted, "<|untrusted|>"),
                     (FormattingToken::EndUntrusted, "<|end_untrusted|>"),
+                    (FormattingToken::MetaSep, "<|meta_sep|>"),
+                    (FormattingToken::MetaEnd, "<|meta_end|>"),
                 ]),
                 stop_formatting_tokens: HashSet::from([
                     FormattingToken::EndMessageDoneSampling,


### PR DESCRIPTION
Change:
- Corrected the MetaSep formatting token to map to `<|meta_sep|>` instead of the `channel` token mapping.
- Registered `MetaSep` and `MetaEnd` with their corresponding `<|meta_sep|>` and `<|meta_end|>` tokens so both native and WASM builds recognize these meta formatting tokens.

---
_This PR was originally from a fork: **neuralsorcerer/harmony** (branch: `patch-1`)_